### PR TITLE
Change Docker Hub organization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 env:
   global:
-    - IMAGE_NAME=dhsncats/gatherer
+    - IMAGE_NAME=cisagov/gatherer
     - DOCKER_USER=jsf9k
     - secure: "zIyHkDg9thZRegsFjQDTSqpuqkybIQSrQarUfsXJLJR1rAm7s1qeDT1I3AlNyY8x4RgY5PreFqRM3ebsFpHSUmXFS0ECiYVO6aJQ409Hx5wUhbEN1hpwocVJ8iC4tEf7/xv5Lu8LTUlD5/wwEhkcgs5p5OTFfEXu9iZGPQT7lZQMYlch855DvzGNr0TON/biPQ3QK70QtcyJyLsIErQbSkPw7SvhuPrY/HOW/CqbgkVkCqQQL9/M8FfwUzV/iIftAWFU2+vEN2leNmqI69CLEToyhljVK80uMoNJtC3NCeVVnaLhLtLObdASPt1+MIngKe/wxhciNXALAxLr87+MeeouYj/VrF34DZa3+qRcwby7nfTZIBFqpJ4ne+Nf63XXtbhNIkEL43kPILCu2nx1EHvlOCVYOJV4dKYxpAmF+/DERxJDQH/ZL0ltAb5j8nac1HdB/AnrKEhMvSZiOUT1lx1y2x4rQeThOYb9+Qaxejukxcuq0ykreJa7hxSiZ5o4hXlX24PAq3awqDSHk5GHBA6WaBQifuOoYIqypOm4JfvzfzXHYSmWSCZCG6NBKSX8iTIrHhQ8Anhc60zZwXudfhKzeUxa8HTh4jHtGI2dJxON1ajoxWnUovKuNPtfvl+yIjAN9cU4KazFnMu0jnJMxGubhWmAieHM5aeF4MlUQRw="
 

--- a/travis_scripts/build_docker_image.sh
+++ b/travis_scripts/build_docker_image.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -o nounset
+set -o errexit
+set -o pipefail
+
 # semver uses a plus character for the build number (if present).
 # This is invalid for a Docker tag, so we replace it with a minus.
 version=$(./bump_version.sh show|sed "s/+/-/")

--- a/travis_scripts/build_docker_image.sh
+++ b/travis_scripts/build_docker_image.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
-version=$(./bump_version.sh show)
-docker build -t ${IMAGE_NAME}:$version .
+# semver uses a plus character for the build number (if present).
+# This is invalid for a Docker tag, so we replace it with a minus.
+version=$(./bump_version.sh show|sed "s/+/-/")
+docker build -t "$IMAGE_NAME":"$version" .

--- a/travis_scripts/deploy_to_docker_hub.sh
+++ b/travis_scripts/deploy_to_docker_hub.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -o nounset
+set -o errexit
+set -o pipefail
+
 echo "$DOCKER_PW" | docker login -u "$DOCKER_USER" --password-stdin
 # semver uses a plus character for the build number (if present).
 # This is invalid for a Docker tag, so we replace it with a minus.

--- a/travis_scripts/deploy_to_docker_hub.sh
+++ b/travis_scripts/deploy_to_docker_hub.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
 echo "$DOCKER_PW" | docker login -u "$DOCKER_USER" --password-stdin
-version=$(./bump_version.sh show)
-docker push "$IMAGE_NAME":$version
+# semver uses a plus character for the build number (if present).
+# This is invalid for a Docker tag, so we replace it with a minus.
+version=$(./bump_version.sh show|sed "s/+/-/")
+docker push "$IMAGE_NAME":"$version"


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

Rename the Docker image so that it belongs to the cisagov organization instead of the dhsncats organization.

Also update some scripts that are used by TravisCI so that they can handle build numbers in the version string.  (Stolen from cisagov/scanner.)

## 💭 Motivation and Context

We are migrating to the cisagov organization.

## 🧪 Testing

The TravisCI checks pass.

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
