### PR TITLE
Update Pointer for Other-Websites Reference

### DIFF
--- a/gather-domains.sh
+++ b/gather-domains.sh
@@ -96,7 +96,7 @@ $HOME_DIR/domain-scan/gather current_federal,analytics_usa_gov,censys_snapshot,r
                              --eot_2012=https://raw.githubusercontent.com/cisagov/scan-target-data/develop/eot-2012.csv \
                              --eot_2016=https://raw.githubusercontent.com/cisagov/scan-target-data/develop/eot-2016.csv \
                              --cyhy=$OUTPUT_DIR/cyhy_fed_hostnames.csv \
-                             --other=https://raw.githubusercontent.com/GSA/data/master/dotgov-websites/other-websites.csv
+                             --other=https://raw.githubusercontent.com/cisagov/dotgov-data/blob/main/dotgov-websites/other-websites.csv
 cp results/gathered.csv gathered.csv
 cp results/gathered.csv $OUTPUT_DIR/gathered.csv
 

--- a/gather-domains.sh
+++ b/gather-domains.sh
@@ -96,7 +96,7 @@ $HOME_DIR/domain-scan/gather current_federal,analytics_usa_gov,censys_snapshot,r
                              --eot_2012=https://raw.githubusercontent.com/cisagov/scan-target-data/develop/eot-2012.csv \
                              --eot_2016=https://raw.githubusercontent.com/cisagov/scan-target-data/develop/eot-2016.csv \
                              --cyhy=$OUTPUT_DIR/cyhy_fed_hostnames.csv \
-                             --other=https://raw.githubusercontent.com/cisagov/dotgov-data/blob/main/dotgov-websites/other-websites.csv
+                             --other=https://raw.githubusercontent.com/cisagov/dotgov-data/main/dotgov-websites/other-websites.csv
 cp results/gathered.csv gathered.csv
 cp results/gathered.csv $OUTPUT_DIR/gathered.csv
 


### PR DESCRIPTION
Hi there, I think it'd be great if we can update our domain gatherer to look at the other-websites list we maintain rather than GSA's since I don't believe they are maintaining their list any more.  Our list at this point is current with theirs, and I've also set up notifications on their GSA/data repo to keep an eye out just in case anyone else makes changes there in the future so we can make the same change here.

## 🗣 Description ##

Update the other-websites URL referenced in gather-domains.sh by replacing  `--other=https://raw.githubusercontent.com/GSA/data/master/dotgov-websites/other-websites.csv` with `--other=https://raw.githubusercontent.com/cisagov/dotgov-data/blob/main/dotgov-websites/other-websites.csv`

## 💭 Motivation and context ##

 -- Why is this change required? --
This change allows us to maintain our own reference source which informs the BOD 18-01 reporting scope for Federal agencies.

-- What problem does this change solve? How did you solve it? --
It doesn't appear GSA is very responsive to changes requested at the currently listed URL, and CISA has primarily been the only org making changes over the past couple years. Listing our own URL as the reference allows us to more quickly ensure changes are implemented.

-- Any related issue(s) --
https://github.com/GSA/data/issues/322

## 🧪 Testing ##

Tested by putting the new URL into my browser :) Realized /blob in the URL causes a 404, but removing it solves the issue so will update the commit in a second.

## ✅ Checklist ##

* [X] This PR has an informative and human-readable title.
* [X] Changes are limited to a single goal - _eschew scope creep!_
* [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [ ] All relevant type-of-change labels have been added.
* [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [ ] Tests have been added and/or modified to cover the changes in this PR.
* [ ] All new and existing tests pass.
