### PR TITLE
Remove unnecessary lovesegfault/beautysh directive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM python:3.12.1-slim-bullseye
 #
 # Note: Additional labels are added by the build workflow.
 ###
-LABEL org.opencontainers.image.authors="vm-fusion-dev-group@trio.dhs.gov"
+LABEL org.opencontainers.image.authors="vm-dev@gwe.cisa.dhs.gov"
 LABEL org.opencontainers.image.vendor="Cybersecurity and Infrastructure Security Agency"
 
 ###

--- a/src/gather-domains.sh
+++ b/src/gather-domains.sh
@@ -85,17 +85,11 @@ sed -i '/[^,]*,[^,]*,Library of Congress,/d;/[^,]*,[^,]*,Government Publishing O
 # of these top-level domains is automatically extracted into the
 # TOP_LEVEL_DOMAINS variable.
 ###
-# beautysh doesn't handle this multiline $() correctly, so we have to
-# temporarily turn off the formatting.  I created
-# lovesegfault/beautysh#82 to document this.
-#
-# @formatter:off
 TOP_LEVEL_DOMAINS=$(cut --delimiter=, --fields=1 $OUTPUT_DIR/current-federal_modified.csv \
   | awk -F"." '{if (NR > 1) print "."$NF;}' \
   | sort --ignore-case --unique \
   | tr "[:upper:]" "[:lower:]" \
   | paste --serial --delimiters=,)
-# @formatter:on
 $HOME_DIR/domain-scan/gather current_federal,analytics_usa_gov,censys_snapshot,rapid,eot_2012,eot_2016,cyhy,other \
   --suffix="$TOP_LEVEL_DOMAINS" --ignore-www --include-parents \
   --parents=$OUTPUT_DIR/current-federal_modified.csv \


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes an unnecessary [lovesegfault/beautysh](https://github.com/lovesegfault/beautysh) directive.  It also updates the `Dockerfile` to use the most recent incarnation of our VM developer distro email address.

## 💭 Motivation and context ##

We no longer use [lovesegfault/beautysh](https://github.com/lovesegfault/beautysh) for linting, so there is no longer any need to work around its limitations.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.