### PR TITLE
Upgrade the version of the `bash` system package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN groupadd --system --gid ${CISA_GID} ${CISA_GROUP} \
 RUN apt update --quiet --quiet \
     && apt install --quiet --quiet --yes \
     --no-install-recommends --no-install-suggests \
-        bash=5.2.37-2+b5 \
+        bash=5.2.37-2+b7 \
         redis-tools=5:8.0.2-3+deb13u1 \
         wget=1.25.0-2 \
     && apt --quiet --quiet clean \


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades the version of the `bash` system package that is installed in the build stage of the `Dockerfile`.

## 💭 Motivation and context ##

Version 5.2.37-2+b5 is no longer available from Debian and this is [breaking the build](https://github.com/cisagov/gatherer/actions/runs/21027250310/job/60454670914).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.